### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/content/pages/solvers.rst
+++ b/content/pages/solvers.rst
@@ -5,11 +5,11 @@ Game solvers
 .. For two-player games, the first two link to solvers that work with exact arithmetic, which is important for finding exact Nash equilibria.
 
 * `Game Theory Explorer <http://gte.csc.liv.ac.uk/index>`_
-  (also see `this Computational Management Science paper <http://dx.doi.org/10.1007/s10287-014-0206-x>`_,
+  (also see `this Computational Management Science paper <https://doi.org/10.1007/s10287-014-0206-x>`_,
   available as pdf on `arXiv <http://arxiv.org/abs/1403.3969>`_)
 
 * `Bimatrix Game Solver <http://banach.lse.ac.uk>`_  
-  (also see `this Economic Theory paper <http://dx.doi.org/10.1007/s00199-009-0449-x>`_, 
+  (also see `this Economic Theory paper <https://doi.org/10.1007/s00199-009-0449-x>`_, 
   available as pdf `here <http://cgi.csc.liv.ac.uk/~rahul/papers/avisetal.pdf>`_)
 
 * `Gambit: Software Tools for Game Theory <http://www.gambit-project.org>`_

--- a/content/rs_pubs_web.bib
+++ b/content/rs_pubs_web.bib
@@ -264,13 +264,13 @@ Optional fields: volume, series, address, edition, month, note, key
   title = {{G}ame {T}heory {E}xplorer: software for the applied game theorist},
   journal = {Computational Management Science},
   doi = {10.1007/s10287-014-0206-x},
-  url = {http://dx.doi.org/10.1007/s10287-014-0206-x},
+  url = {https://doi.org/10.1007/s10287-014-0206-x},
   arxiv = {http://arxiv.org/abs/1403.3969},
 }
 
 @article{GSSV12,
   doi = {10.1007/s00182-012-0362-6},
-  url = {http://dx.doi.org/10.1007/s00182-012-0362-6},
+  url = {https://doi.org/10.1007/s00182-012-0362-6},
   year  = {2013},
   publisher = {Springer Science $\mathplus$ Business Media},
   volume = {42},
@@ -294,7 +294,7 @@ Optional fields: volume, series, address, edition, month, note, key
   journal = {{ACM} Transactions on Economics and Computation},
   note = {Preliminary conference version appeared at FOCS 2011},
   doi = {10.1145/2465769.2465774},
-  url = {http://dx.doi.org/10.1145/2465769.2465774},
+  url = {https://doi.org/10.1145/2465769.2465774},
   arxiv = {http://arxiv.org/abs/1006.5352},
 }
 
@@ -308,12 +308,12 @@ Optional fields: volume, series, address, edition, month, note, key
   title = {High-Frequency Trading: The Faster,  the Better?},
   journal = {{IEEE} Intelligent Systems},
   doi = {10.1109/mis.2012.75},
-  url = {http://dx.doi.org/10.1109/MIS.2012.75},
+  url = {https://doi.org/10.1109/MIS.2012.75},
 }
 
 @article{ARSvS10,
   doi = {10.1007/s00199-009-0449-x},
-  url = {http://dx.doi.org/10.1007/s00199-009-0449-x},
+  url = {https://doi.org/10.1007/s00199-009-0449-x},
   year  = {2009},
   publisher = {Springer Science $\mathplus$ Business Media},
   volume = {42},
@@ -335,7 +335,7 @@ Optional fields: volume, series, address, edition, month, note, key
   title = {Good neighbors are hard to find: computational complexity of network formation},
   journal = {Review of Economic Design},
   doi = {10.1007/s10058-008-0043-x},
-  url = {http://dx.doi.org/10.1007/s10058-008-0043-x},
+  url = {https://doi.org/10.1007/s10058-008-0043-x},
   pdf = {http://cgi.csc.liv.ac.uk/~rahul/papers/red.pdf}
 }
 
@@ -350,7 +350,7 @@ Optional fields: volume, series, address, edition, month, note, key
   journal = {Econometrica},
   note = {Preliminary conference version appeared at FOCS 2004},
   doi = {10.1111/j.1468-0262.2006.00667.x},
-  url = {http://dx.doi.org/10.1111/j.1468-0262.2006.00667.x},
+  url = {https://doi.org/10.1111/j.1468-0262.2006.00667.x},
   pdf = {http://www.maths.lse.ac.uk/Personal/stengel/TEXTE/ecta2006.pdf},
 }
 
@@ -365,7 +365,7 @@ Optional fields: volume, series, address, edition, month, note, key
   title = {Mixed-species aggregations in birds: zenaida doves,  {Z}enaida aurita,  respond to the alarm calls of carib grackles,  {Q}uiscalus lugubris},
   journal = {Animal Behaviour},
   doi = {10.1016/j.anbehav.2004.11.023},
-  url = {http://dx.doi.org/10.1016/j.anbehav.2004.11.023},
+  url = {https://doi.org/10.1016/j.anbehav.2004.11.023},
   pdf = {http://cgi.csc.liv.ac.uk/~rahul/papers/ab.pdf},
 }
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -513,7 +513,7 @@ Optional fields: volume, series, address, edition, month, note, key
   booktitle = {Proc.\ of the Conference on Web and Internet Economics (\textbf{{WINE}})},
   shorttitle = {WINE 2014},
   doi = {10.1007/978-3-319-13129-0_5},
-  url = {http://dx.doi.org/10.1007/978-3-319-13129-0_5},
+  url = {https://doi.org/10.1007/978-3-319-13129-0_5},
   arxiv = {http://arxiv.org/abs/1409.3741},
   note = {Journal version appeared in Algorithmica (2017)},
 }
@@ -527,7 +527,7 @@ Optional fields: volume, series, address, edition, month, note, key
   shorttitle = {EC 2014},
   note = {Journal version appeared in TEAC (2016)},
   doi = {10.1145/2600057.2602847},
-  url = {http://dx.doi.org/10.1145/2600057.2602847},
+  url = {https://doi.org/10.1145/2600057.2602847},
   arxiv = {http://arxiv.org/abs/1310.7419},
   pages = {657--674}
 }
@@ -603,7 +603,7 @@ Optional fields: volume, series, address, edition, month, note, key
   booktitle = {Proc.\ of the Symposium on Algorithmic Game Theory (\textbf{{SAGT}})},
   shorttitle = {SAGT 2012},
   doi = {10.1007/978-3-642-33996-7_10},
-  url = {http://dx.doi.org/10.1007/978-3-642-33996-7_10},
+  url = {https://doi.org/10.1007/978-3-642-33996-7_10},
   arxiv = {http://arxiv.org/abs/1204.0707},
   note = {Journal version appeared in Algorithmica (2016)},
 }
@@ -616,7 +616,7 @@ Optional fields: volume, series, address, edition, month, note, key
   shorttitle = {FOCS 2011},
   note = {Journal version appeared in TEAC (2013)},
   doi = {10.1109/focs.2011.26},
-  url = {http://dx.doi.org/10.1109/FOCS.2011.26},
+  url = {https://doi.org/10.1109/FOCS.2011.26},
   arxiv = {http://arxiv.org/abs/1006.5352},
   pages={67--76}
 }
@@ -630,7 +630,7 @@ Optional fields: volume, series, address, edition, month, note, key
   shorttitle = {ESA 2011},
   note = {Journal version appeared in IJGT (2013)},
   doi = {10.1007/978-3-642-23719-5_9},
-  url = {http://dx.doi.org/10.1007/978-3-642-23719-5_9},
+  url = {https://doi.org/10.1007/978-3-642-23719-5_9},
   arxiv = {http://arxiv.org/abs/1103.1040},
 }
 
@@ -650,7 +650,7 @@ Optional fields: volume, series, address, edition, month, note, key
   year      = {2010},
   title     = {Computing Stable Outcomes in Hedonic Games},
   pages     = {174--185},
-  url       = {http://dx.doi.org/10.1007/978-3-642-16170-4_16},
+  url       = {https://doi.org/10.1007/978-3-642-16170-4_16},
   doi       = {10.1007/978-3-642-16170-4_16},
   booktitle = {Proc.\ of the Symposium on Algorithmic Game Theory (\textbf{{SAGT}})},
   shorttitle = {SAGT 2010},
@@ -666,7 +666,7 @@ Optional fields: volume, series, address, edition, month, note, key
   booktitle = {Proc.\ of the International Conference on Current Trends in Theory and Practice of Computer Science (\textbf{{SOFSEM}})},
   shorttitle = {SOFSEM 2010},
   doi = {10.1007/978-3-642-11266-9_32},
-  url = {http://dx.doi.org/10.1007/978-3-642-11266-9_32},
+  url = {https://doi.org/10.1007/978-3-642-11266-9_32},
   arxiv = {http://arxiv.org/abs/0909.5653},
   pdf = {http://cgi.csc.liv.ac.uk/~rahul/papers/lemke_discounted.pdf},
 }
@@ -679,7 +679,7 @@ Optional fields: volume, series, address, edition, month, note, key
   booktitle = {Proc.\ of the Workshop on Internet and Network Economics (\textbf{{WINE}})},
   shorttitle = {WINE 2009},
   doi = {10.1007/978-3-642-10841-9_40},
-  url = {http://dx.doi.org/10.1007/978-3-642-10841-9_40},
+  url = {https://doi.org/10.1007/978-3-642-10841-9_40},
   arxiv = {http://arxiv.org/abs/0909.5293},
   pdf = {http://cgi.csc.liv.ac.uk/~rahul/papers/wiretapping.pdf},
 }
@@ -692,7 +692,7 @@ Optional fields: volume, series, address, edition, month, note, key
   booktitle = {Proc.\ of the International Conference on Algorithmic Aspects in Information and Management (\textbf{{AAIM}})},
   shorttitle = {AAIM 2009},
   doi = {10.1007/978-3-642-02158-9_7},
-  url = {http://dx.doi.org/10.1007/978-3-642-02158-9_7},
+  url = {https://doi.org/10.1007/978-3-642-02158-9_7},
   arxiv = {http://arxiv.org/abs/0906.3643},
   pdf = {http://cgi.csc.liv.ac.uk/~rahul/papers/spanning.pdf}
 }
@@ -705,7 +705,7 @@ Optional fields: volume, series, address, edition, month, note, key
   booktitle = {Proc.\ of Computability in Europe (\textbf{{CiE}})},
   shorttitle = {CiE 2008},
   doi = {10.1007/978-3-540-69407-6_32},
-  url = {http://dx.doi.org/10.1007/978-3-540-69407-6_32},
+  url = {https://doi.org/10.1007/978-3-540-69407-6_32},
   pdf = {http://cgi.csc.liv.ac.uk/~rahul/papers/cie08.pdf},
 }
 
@@ -716,7 +716,7 @@ Optional fields: volume, series, address, edition, month, note, key
   booktitle = {Proc.\ of the {IEEE} Symposium on Foundations of Computer Science (\textbf{{FOCS}})},
   shorttitle = {FOCS 2004},
   doi = {10.1109/focs.2004.28},
-  url = {http://dx.doi.org/10.1109/FOCS.2004.28},
+  url = {https://doi.org/10.1109/FOCS.2004.28},
   note = {Journal version appeared in Econometrica (2006)},
   pdf = {http://www.maths.lse.ac.uk/Personal/stengel/TEXTE/focs04.pdf},
   slides = {http://cgi.csc.liv.ac.uk/~rahul/papers/hardtosolve.pdf},

--- a/plugins/pelican-bibtex/rahul_style.py
+++ b/plugins/pelican-bibtex/rahul_style.py
@@ -508,7 +508,7 @@ class Style(BaseStyle):
         # based on urlbst format.doi
         return href [
             join [
-                'http://dx.doi.org/',
+                'https://doi.org/',
                 field('doi')
                 ],
             join [

--- a/themes/notmyidea/templates/publications.html
+++ b/themes/notmyidea/templates/publications.html
@@ -43,7 +43,7 @@
         <li class="pub" id="{{ key }}" data-type="{{ pub_type}}">{{ text }}
 		<!-- Define a link: either create it from the doi, or take it from the url field -->
 		{% if doi is not none%}
-		{% set linkurl = "http://dx.doi.org/%s" % doi %}
+		{% set linkurl = "https://doi.org/%s" % doi %}
 		{% else %}
 		{% set linkurl = url %}
 		{% endif %}

--- a/themes/notmyidea/templates/publicationsandreas-h.html
+++ b/themes/notmyidea/templates/publicationsandreas-h.html
@@ -23,7 +23,7 @@
                 {% set key, year, text, bibtex, doi, url, pdf, slides, poster = pub %}
                 {% if "%s"|format(year) == "%s"|format(yr) %}
                 {% if doi != ""%}
-                {% set linkurl = "http://dx.doi.org/%s" % doi %}
+                {% set linkurl = "https://doi.org/%s" % doi %}
                 {% else %}
                 {% set linkurl = url %}
                 {% endif %}
@@ -44,7 +44,7 @@
                 {% set key, year, text, bibtex, doi, url, pdf, slides, poster = pub %}
                 {% if "%s"|format(year) == "%s"|format(yr) %}
                 {% if doi != ""%}
-                {% set linkurl = "http://dx.doi.org/%s" % doi %}
+                {% set linkurl = "https://doi.org/%s" % doi %}
                 {% else %}
                 {% set linkurl = url %}
                 {% endif %}


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!